### PR TITLE
Correct teal accent color

### DIFF
--- a/config.js
+++ b/config.js
@@ -268,7 +268,7 @@ export class ConfigManager {
       // Map GNOME accent colors to RGBA values with alpha 0.4
       const accentColorMap = {
         blue: "rgba(53, 132, 228, 0.4)",
-        teal: "rgba(51, 209, 122, 0.4)",
+        teal: "rgba(33, 144, 164, 0.4)",
         green: "rgba(46, 194, 126, 0.4)",
         yellow: "rgba(248, 228, 92, 0.4)",
         orange: "rgba(255, 120, 0, 0.4)",


### PR DESCRIPTION
Thank you for creating this extension, this is exactly what I needed!

Apparently rgb values for teal color are wrong and make it greenish while it should be blue. Taking the value from https://gitlab.gnome.org/GNOME/libadwaita/-/blob/main/src/stylesheet/_colors.scss?ref_type=heads#L163.