### PR TITLE
Per-window colours from the window menu, and a window picker in prefs

### DIFF
--- a/bordermanager.js
+++ b/bordermanager.js
@@ -2,8 +2,13 @@ import GLib from "gi://GLib";
 import Meta from "gi://Meta";
 import St from "gi://St";
 import * as Main from "resource:///org/gnome/shell/ui/main.js";
-import { applyBorderState, getWindowState } from "./compat.js";
-import { ConfigManager } from "./config.js";
+import {
+  applyBorderState,
+  applyTitleState,
+  getEffectiveFrame,
+  getWindowState,
+} from "./compat.js";
+import { ConfigManager, WINDOW_OVERRIDE_PROP } from "./config.js";
 
 // We do these live GObject checks as gnome shell can lose it's actors
 // without us being notified correctly. Often happens in cases
@@ -11,6 +16,20 @@ import { ConfigManager } from "./config.js";
 // Some case the shell recovers, some case it might not, but still doing
 // these checks avoid adding extra red-herring and makes things
 // more graceful.
+// Client-side decorated windows draw their headerbar in the app process, so
+// its height cannot be queried from here — only server-side decorations can
+// (see getTitlebarHeight). This is not a guess though: GTK's own themes set
+//   headerbar { min-height: 46px }
+// in both GTK3 (Adwaita/gtk-contained.css) and GTK4 (Default/Default.css),
+// and Yaru inherits that value unchanged. Scaled below for HiDPI.
+const FALLBACK_TITLE_HEIGHT = 46;
+const DEFAULT_TITLE_OPACITY = 0.35;
+
+function getFallbackTitleHeight() {
+  const scale = St.ThemeContext.get_for_stage(global.stage)?.scale_factor || 1;
+  return Math.round(FALLBACK_TITLE_HEIGHT * scale);
+}
+
 const isLiveObject = (object) => {
   if (!object) return false;
   try {
@@ -156,7 +175,12 @@ export class BorderManager {
   // --- Helpers ------------------------------------------------------------
 
   isLiveWindowData(data) {
-    return !!(data && isLiveObject(data.actor) && isLiveObject(data.border));
+    return !!(
+      data &&
+      isLiveObject(data.actor) &&
+      isLiveObject(data.border) &&
+      isLiveObject(data.titleTint)
+    );
   }
 
   _isInterestingWindow(metaWindow) {
@@ -188,12 +212,15 @@ export class BorderManager {
   _hideBorder(data) {
     if (!data) return;
     data.border.visible = false;
+    data.titleTint.visible = false;
     data.borderStyleCache = null;
+    data.titleStyleCache = null;
   }
 
   _invalidateAndUpdate(metaWindow, data) {
     if (!data) return;
     data.borderStyleCache = null;
+    data.titleStyleCache = null;
     this._queueUpdate(metaWindow, data);
   }
 
@@ -285,12 +312,12 @@ export class BorderManager {
   // --- Core geometry + style sync -----------------------------------------
 
   syncBorder(metaWindow, data) {
-    const { border, actor, config } = data;
+    const { border, titleTint, actor, config } = data;
 
     const windowState = getWindowState(metaWindow, actor);
-    const policyState = computeBorderState(windowState, config);
 
-    applyBorderState(border, policyState, data);
+    applyBorderState(border, computeBorderState(windowState, config), data);
+    applyTitleState(titleTint, computeTitleState(windowState, config), data);
   }
 
   // --- Per-window lifecycle -----------------------------------------------
@@ -310,6 +337,26 @@ export class BorderManager {
     this._logWindow(metaWindow, "config updated", config);
   }
 
+  // Sets (or clears, with null) the colour override for one window and
+  // repaints just that window. Called from the window menu.
+  setWindowOverride(metaWindow, override) {
+    if (override) {
+      metaWindow[WINDOW_OVERRIDE_PROP] = override;
+    } else {
+      delete metaWindow[WINDOW_OVERRIDE_PROP];
+    }
+
+    const data = this._windowData.get(metaWindow);
+    if (!data) return;
+
+    data.config = this.configManager.getConfigForWindow(metaWindow);
+    this._invalidateAndUpdate(metaWindow, data);
+  }
+
+  getWindowOverride(metaWindow) {
+    return metaWindow[WINDOW_OVERRIDE_PROP] || null;
+  }
+
   _tryTrackWindow(metaWindow) {
     if (!this._isInterestingWindow(metaWindow)) return;
     if (this._windowData.has(metaWindow)) return;
@@ -325,11 +372,18 @@ export class BorderManager {
       reactive: false,
       visible: false,
     });
+    const titleTint = new St.Widget({
+      reactive: false,
+      visible: false,
+    });
 
     // Ensure we can draw outside if "outer" expands
     actor.clip_to_allocation = false;
     border.clip_to_allocation = false;
 
+    // Tint sits under the border so the border edge stays crisp over it.
+    actor.add_child(titleTint);
+    actor.set_child_above_sibling(titleTint, null);
     actor.add_child(border);
     actor.set_child_above_sibling(border, null);
 
@@ -337,15 +391,25 @@ export class BorderManager {
 
     const windowData = {
       border,
+      titleTint,
       actor,
       config,
       borderStyleCache: null,
+      titleStyleCache: null,
     };
     this._windowData.set(metaWindow, windowData);
 
     actor.connectObject(
       "notify::allocation",
       () => this._queueUpdate(metaWindow, windowData),
+      "destroy",
+      () => {
+        // The actor took its children down with it. Drop the references so
+        // nothing downstream touches disposed widgets.
+        windowData.border = null;
+        windowData.titleTint = null;
+        this._untrackWindow(metaWindow);
+      },
       this,
     );
     metaWindow.connectObject(
@@ -410,12 +474,14 @@ export class BorderManager {
 
     this._logWindow(metaWindow, "untrack", data.config);
 
-    const { border, actor } = data;
+    const { border, titleTint, actor } = data;
     if (isLiveObject(metaWindow)) metaWindow.disconnectObject(this);
     if (isLiveObject(actor)) actor.disconnectObject(this);
 
-    if (this.isLiveWindowData(data) && border.get_parent?.() === actor) {
-      actor.remove_child(border);
+    if (this.isLiveWindowData(data)) {
+      for (const child of [border, titleTint]) {
+        if (child?.get_parent?.() === actor) actor.remove_child(child);
+      }
     }
 
     this._windowData.delete(metaWindow);
@@ -505,11 +571,44 @@ export class BorderManager {
   }
 }
 
+// The title bar itself cannot be recoloured: CSD apps paint it in their own
+// process, and SSD frames come from mutter's GTK theme. Laying a translucent
+// wash over that strip tints it while leaving the title and buttons legible.
+function computeTitleState(windowState, config) {
+  const { isFullscreen, maximize, titlebarHeight, isFocused } = windowState;
+
+  if (!config.enabled || !config.titleTint || isFullscreen) {
+    return { visible: false };
+  }
+
+  const effectiveFrame = getEffectiveFrame(windowState);
+  // Measured height wins. Failing that, a per-app override, then the scaled
+  // fallback — CSD apps never reach the first branch.
+  const height = Math.min(
+    titlebarHeight || config.titleHeight || getFallbackTitleHeight(),
+    effectiveFrame.height,
+  );
+
+  if (height <= 0 || effectiveFrame.width <= 0) return { visible: false };
+
+  return {
+    visible: true,
+    pos: { x: effectiveFrame.x, y: effectiveFrame.y },
+    size: { width: effectiveFrame.width, height },
+    color: config.titleColor ??
+      (isFocused ? config.activeColor : config.inactiveColor),
+    opacity: Math.round(
+      (config.titleOpacity ?? DEFAULT_TITLE_OPACITY) * 255,
+    ),
+    radius: maximize.any
+      ? { tl: 0, tr: 0 }
+      : { tl: config.radius.tl, tr: config.radius.tr },
+  };
+}
+
 function computeBorderState(windowState, config) {
   const {
-    box,
     frame,
-    buffer,
     workarea,
     isFullscreen,
     maximize,
@@ -532,19 +631,7 @@ function computeBorderState(windowState, config) {
 
   // We calculate the effective frame so that any additional shadows
   // that's drawn by the actors aren't counted for the border.
-  const effectiveFrame = buffer
-    ? {
-      x: frame.x - buffer.x,
-      y: frame.y - buffer.y,
-      width: frame.width,
-      height: frame.height,
-    }
-    : {
-      x: 0,
-      y: 0,
-      width: box.width,
-      height: box.height,
-    };
+  const effectiveFrame = getEffectiveFrame(windowState);
 
   const { width, height } = effectiveFrame;
   if (width <= 0 || height <= 0) {

--- a/compat.js
+++ b/compat.js
@@ -26,6 +26,19 @@ export function getMaximizeState(metaWindow) {
   return { any, full, horizontal, vertical };
 }
 
+// Height of the server-drawn titlebar. Returns 0 for client-side decorated
+// windows: the app draws its own headerbar, so there is nothing to measure
+// and callers fall back to a configured height.
+export function getTitlebarHeight(metaWindow) {
+  if (metaWindow.is_client_decorated?.()) return 0;
+
+  const frame = metaWindow.get_frame_rect();
+  const client = metaWindow.frame_rect_to_client_rect?.(frame);
+  if (!client) return 0;
+
+  return Math.max(0, client.y - frame.y);
+}
+
 export function getWindowState(metaWindow, actor) {
   const box = actor.get_allocation_box();
   const width = box.x2 - box.x1;
@@ -43,9 +56,51 @@ export function getWindowState(metaWindow, actor) {
     buffer,
     workarea,
     maximize,
+    titlebarHeight: getTitlebarHeight(metaWindow),
     isFullscreen: !!metaWindow.fullscreen,
     isFocused: metaWindow === global.display.focus_window,
   };
+}
+
+// Frame position relative to the actor, with any shadow the actor draws
+// discounted. Shared by the border and the title tint.
+export function getEffectiveFrame({ box, frame, buffer }) {
+  if (!buffer) {
+    return { x: 0, y: 0, width: box.width, height: box.height };
+  }
+  return {
+    x: frame.x - buffer.x,
+    y: frame.y - buffer.y,
+    width: frame.width,
+    height: frame.height,
+  };
+}
+
+export function applyTitleState(tint, state, cache) {
+  if (!state.visible) {
+    tint.visible = false;
+    if (cache) cache.titleStyleCache = null;
+    return;
+  }
+
+  tint.set_position(state.pos.x, state.pos.y);
+  tint.set_size(state.size.width, state.size.height);
+
+  const { color, radius } = state;
+  const styleKey = `${color}|${radius.tl},${radius.tr}`;
+
+  if (cache?.titleStyleCache !== styleKey) {
+    tint.set_style(
+      `background-color: ${color};` +
+        `border-radius: ${radius.tl}px ${radius.tr}px 0 0;`,
+    );
+  }
+
+  // Opacity lives on the actor rather than in the colour string, so the
+  // configured colour can stay in any format St accepts.
+  tint.opacity = state.opacity;
+  tint.visible = true;
+  if (cache) cache.titleStyleCache = styleKey;
 }
 
 export function applyBorderState(border, state, cache) {

--- a/config.js
+++ b/config.js
@@ -1,6 +1,11 @@
 // config.js
 
 import Gio from "gi://Gio";
+
+// Expando on Meta.Window carrying a single-window colour override.
+export const WINDOW_OVERRIDE_PROP = "__p7BorderOverride";
+const WINDOW_MERGED_PROP = "__p7BorderMerged";
+
 export class ConfigManager {
   constructor(settings, logger) {
     // Use the settings object provided by Extension.getSettings()
@@ -359,7 +364,32 @@ export class ConfigManager {
     return resolvedConfigs;
   }
 
+  // A per-window override beats the app config. Stored on the Meta.Window
+  // itself so it dies with the window — window ids are not stable across
+  // sessions, so persisting it would be meaningless anyway.
+  // ponytail: overrides only carry colors/enabled, which normalizeConfig
+  // does not touch, so merging onto the normalized app config is safe.
   getConfigForWindow(metaWindow) {
+    const appConfig = this._getAppConfigForWindow(metaWindow);
+    const override = metaWindow[WINDOW_OVERRIDE_PROP];
+    if (!override) return appConfig;
+
+    // Memoised so the returned object keeps a stable identity — callers
+    // compare configs by reference to decide whether to repaint, and a
+    // fresh merge on every title change would repaint constantly.
+    let cache = metaWindow[WINDOW_MERGED_PROP];
+    if (!cache || cache.base !== appConfig || cache.override !== override) {
+      cache = {
+        base: appConfig,
+        override,
+        merged: { ...appConfig, ...override },
+      };
+      metaWindow[WINDOW_MERGED_PROP] = cache;
+    }
+    return cache.merged;
+  }
+
+  _getAppConfigForWindow(metaWindow) {
     const appId = metaWindow.get_gtk_application_id?.() || "";
     const wmClass = metaWindow.get_wm_class?.() || "";
 

--- a/extension.js
+++ b/extension.js
@@ -2,6 +2,7 @@
 
 import { Extension } from "resource:///org/gnome/shell/extensions/extension.js";
 import { BorderManager } from "./bordermanager.js";
+import { WindowListService } from "./windowlist.js";
 
 export default class P7BordersExtension extends Extension {
   constructor(metadata) {
@@ -18,10 +19,17 @@ export default class P7BordersExtension extends Extension {
 
     this._borderManager = new BorderManager(this._logger, this.getSettings());
     this._borderManager.enable();
+
+    this._windowList = new WindowListService(this._logger);
+    this._windowList.enable();
   }
 
   disable() {
     this._logger.log("Extension disabled");
+    if (this._windowList) {
+      this._windowList.disable();
+      this._windowList = null;
+    }
     if (this._borderManager) {
       this._borderManager.disable();
       this._borderManager = null;

--- a/extension.js
+++ b/extension.js
@@ -3,6 +3,7 @@
 import { Extension } from "resource:///org/gnome/shell/extensions/extension.js";
 import { BorderManager } from "./bordermanager.js";
 import { WindowListService } from "./windowlist.js";
+import { WindowMenuIntegration } from "./windowmenu.js";
 
 export default class P7BordersExtension extends Extension {
   constructor(metadata) {
@@ -22,10 +23,20 @@ export default class P7BordersExtension extends Extension {
 
     this._windowList = new WindowListService(this._logger);
     this._windowList.enable();
+
+    this._windowMenu = new WindowMenuIntegration(
+      this._borderManager,
+      this._logger,
+    );
+    this._windowMenu.enable();
   }
 
   disable() {
     this._logger.log("Extension disabled");
+    if (this._windowMenu) {
+      this._windowMenu.disable();
+      this._windowMenu = null;
+    }
     if (this._windowList) {
       this._windowList.disable();
       this._windowList = null;

--- a/prefs.js
+++ b/prefs.js
@@ -10,6 +10,107 @@ const APP_CONFIGS_KEY = "app-configs";
 const CUSTOM_LABEL = "Custom";
 const DEFAULT_PRESET_KEY = "@default";
 
+// ponytail: the shell side owns the window list; prefs is a separate process
+// and cannot reach mutter directly. See windowlist.js.
+function listOpenWindows(callback) {
+  Gio.DBus.session.call(
+    "org.gnome.Shell.Extensions.P7Borders",
+    "/org/gnome/shell/extensions/p7borders",
+    "org.gnome.Shell.Extensions.P7Borders",
+    "ListWindows",
+    null,
+    new GLib.VariantType("(s)"),
+    Gio.DBusCallFlags.NONE,
+    -1,
+    null,
+    (_src, res) => {
+      try {
+        const [json] = Gio.DBus.session.call_finish(res).deepUnpack();
+        callback(JSON.parse(json), null);
+      } catch (err) {
+        callback(null, err);
+      }
+    },
+  );
+}
+
+// Button that pops up the currently open windows and writes the chosen
+// app's key into `entry`. Preferred key is class:, app: is the fallback.
+function createWindowPickerButton(entry) {
+  const button = new Gtk.MenuButton({
+    icon_name: "focus-windows-symbolic",
+    tooltip_text: "Pick an open window",
+    valign: Gtk.Align.CENTER,
+  });
+  const popover = new Gtk.Popover({ width_request: 320 });
+  button.set_popover(popover);
+
+  popover.connect("show", () => {
+    const box = new Gtk.Box({
+      orientation: Gtk.Orientation.VERTICAL,
+      spacing: 6,
+    });
+    box.append(new Gtk.Label({ label: "Loading…", xalign: 0 }));
+    popover.set_child(box);
+
+    listOpenWindows((windows, err) => {
+      const content = new Gtk.Box({
+        orientation: Gtk.Orientation.VERTICAL,
+        spacing: 6,
+      });
+
+      if (err) {
+        content.append(new Gtk.Label({
+          label: "Could not reach the extension.\nIs it enabled?",
+          xalign: 0,
+          css_classes: ["dim-label"],
+        }));
+        popover.set_child(content);
+        return;
+      }
+
+      const list = new Gtk.ListBox({
+        selection_mode: Gtk.SelectionMode.NONE,
+        css_classes: ["boxed-list"],
+      });
+
+      for (const win of windows) {
+        const key = win.wmClass ? `class:${win.wmClass}` : `app:${win.appId}`;
+        const row = new Adw.ActionRow({
+          title: key,
+          subtitle: win.title,
+          activatable: true,
+        });
+        row.connect("activated", () => {
+          entry.text = key.toLowerCase();
+          popover.popdown();
+        });
+        list.append(row);
+      }
+
+      if (!windows.length) {
+        content.append(new Gtk.Label({
+          label: "No open windows found.",
+          xalign: 0,
+          css_classes: ["dim-label"],
+        }));
+      } else {
+        const scroller = new Gtk.ScrolledWindow({
+          propagate_natural_height: true,
+          max_content_height: 400,
+          hscrollbar_policy: Gtk.PolicyType.NEVER,
+        });
+        scroller.set_child(list);
+        content.append(scroller);
+      }
+
+      popover.set_child(content);
+    });
+  });
+
+  return button;
+}
+
 function parseAppConfigs(settings) {
   const raw = settings.get_string(APP_CONFIGS_KEY);
   if (!raw) return {};
@@ -726,7 +827,8 @@ function buildConfigsPage(settings, initialConfigs, registerSettingsHandler) {
 
   const addKeyInfoRow = new Adw.ActionRow({
     title: "Key",
-    subtitle: "Use app:ID, class:WM_CLASS, or regex.class:pattern",
+    subtitle:
+      "Use the window button, or type app:ID / class:WM_CLASS / regex.class:pattern",
   });
   addExpander.add_row(addKeyInfoRow);
   const addEntry = new Gtk.Entry({
@@ -734,8 +836,14 @@ function buildConfigsPage(settings, initialConfigs, registerSettingsHandler) {
     halign: Gtk.Align.FILL,
     placeholder_text: "class:org.gnome.Terminal",
   });
+  const addEntryBox = new Gtk.Box({
+    orientation: Gtk.Orientation.HORIZONTAL,
+    spacing: 6,
+  });
+  addEntryBox.append(addEntry);
+  addEntryBox.append(createWindowPickerButton(addEntry));
   const addEntryRow = new Adw.PreferencesRow({ hexpand: true });
-  addEntryRow.set_child(addEntry);
+  addEntryRow.set_child(addEntryBox);
   addExpander.add_row(addEntryRow);
 
   const addPresetRow = new Adw.ComboRow({

--- a/windowlist.js
+++ b/windowlist.js
@@ -1,0 +1,75 @@
+// windowlist.js
+// ponytail: exposes open windows over D-Bus so prefs can offer a picker
+// instead of making the user type WM_CLASS by hand. Read-only, no state.
+
+import Gio from "gi://Gio";
+import Meta from "gi://Meta";
+
+const BUS_NAME = "org.gnome.Shell.Extensions.P7Borders";
+const OBJECT_PATH = "/org/gnome/shell/extensions/p7borders";
+
+const IFACE = `
+<node>
+  <interface name="org.gnome.Shell.Extensions.P7Borders">
+    <method name="ListWindows">
+      <arg type="s" direction="out" name="json"/>
+    </method>
+  </interface>
+</node>`;
+
+export class WindowListService {
+  constructor(logger) {
+    this._logger = logger;
+    this._impl = null;
+    this._ownerId = 0;
+  }
+
+  enable() {
+    this._impl = Gio.DBusExportedObject.wrapJSObject(IFACE, this);
+    this._impl.export(Gio.DBus.session, OBJECT_PATH);
+    this._ownerId = Gio.bus_own_name(
+      Gio.BusType.SESSION,
+      BUS_NAME,
+      Gio.BusNameOwnerFlags.REPLACE,
+      null,
+      null,
+      null,
+    );
+  }
+
+  disable() {
+    if (this._ownerId) {
+      Gio.bus_unown_name(this._ownerId);
+      this._ownerId = 0;
+    }
+    if (this._impl) {
+      this._impl.unexport();
+      this._impl = null;
+    }
+  }
+
+  ListWindows() {
+    const seen = new Set();
+    const windows = [];
+
+    for (const w of global.display.list_all_windows()) {
+      if (w.get_window_type() !== Meta.WindowType.NORMAL) continue;
+
+      const wmClass = w.get_wm_class() || "";
+      const appId = w.get_gtk_application_id?.() || "";
+      if (!wmClass && !appId) continue;
+
+      // One entry per app, not per window — configs are keyed by app.
+      const dedupeKey = `${wmClass} ${appId}`;
+      if (seen.has(dedupeKey)) continue;
+      seen.add(dedupeKey);
+
+      windows.push({ wmClass, appId, title: w.get_title() || "" });
+    }
+
+    windows.sort((a, b) =>
+      (a.wmClass || a.appId).localeCompare(b.wmClass || b.appId)
+    );
+    return JSON.stringify(windows);
+  }
+}

--- a/windowmenu.js
+++ b/windowmenu.js
@@ -1,0 +1,144 @@
+// windowmenu.js
+// ponytail: monkeypatches the shell's window menu (right-click titlebar /
+// Alt+Space) with a colour submenu, so a window can be recoloured in place.
+// Scoped to the single window; app-wide colours belong to prefs.
+
+import Clutter from "gi://Clutter";
+import St from "gi://St";
+
+import * as PopupMenu from "resource:///org/gnome/shell/ui/popupMenu.js";
+import * as WindowMenu from "resource:///org/gnome/shell/ui/windowMenu.js";
+
+const COLORS = [
+  { name: "Red", value: "#ef4444" },
+  { name: "Orange", value: "#f97316" },
+  { name: "Yellow", value: "#eab308" },
+  { name: "Green", value: "#22c55e" },
+  { name: "Teal", value: "#14b8a6" },
+  { name: "Blue", value: "#3b82f6" },
+  { name: "Purple", value: "#a855f7" },
+  { name: "Pink", value: "#ec4899" },
+  { name: "Grey", value: "#94a3b8" },
+];
+
+function createSwatch(color) {
+  return new St.Widget({
+    style: `background-color: ${color}; border-radius: 4px;` +
+      " width: 14px; height: 14px; margin-right: 8px;",
+    y_align: Clutter.ActorAlign.CENTER,
+  });
+}
+
+export class WindowMenuIntegration {
+  constructor(borderManager, logger) {
+    this._borderManager = borderManager;
+    this._logger = logger;
+    this._originalShow = null;
+  }
+
+  // WindowMenu is a plain ES class (no GObject _init to patch), and
+  // WindowMenuManager builds it via a module-local binding, so replacing the
+  // export would not help either. The manager method is the usable seam:
+  // wrap it, and intercept the menu as it is handed to the popup manager.
+  enable() {
+    const proto = WindowMenu.WindowMenuManager.prototype;
+    this._originalShow = proto.showWindowMenuForWindow;
+
+    // Bail loudly rather than silently patching a method that is not there.
+    if (typeof this._originalShow !== "function") {
+      this._originalShow = null;
+      this._logger.warn?.("showWindowMenuForWindow missing, menu not patched");
+      return;
+    }
+
+    const originalShow = this._originalShow;
+    const self = this;
+    proto.showWindowMenuForWindow = function (metaWindow, type, rect) {
+      const popupManager = this._manager;
+      const originalAddMenu = popupManager.addMenu;
+
+      popupManager.addMenu = function (menu, ...rest) {
+        originalAddMenu.call(this, menu, ...rest);
+        try {
+          self._appendColorSection(menu, metaWindow);
+        } catch (err) {
+          self._logger.warn?.(`colour section failed: ${err}`);
+        }
+      };
+
+      try {
+        originalShow.call(this, metaWindow, type, rect);
+      } finally {
+        popupManager.addMenu = originalAddMenu;
+      }
+    };
+  }
+
+  disable() {
+    if (this._originalShow) {
+      WindowMenu.WindowMenuManager.prototype.showWindowMenuForWindow =
+        this._originalShow;
+      this._originalShow = null;
+    }
+  }
+
+  // One entry in the window menu, scoped to this window only. App-wide
+  // colours live in the extension preferences instead.
+  _appendColorSection(menu, metaWindow) {
+    menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+
+    const root = new PopupMenu.PopupSubMenuMenuItem("Window colour", false);
+    menu.addMenuItem(root);
+    const sub = root.menu;
+
+    sub.addMenuItem(new PopupMenu.PopupSeparatorMenuItem("This window"));
+    this._addColorItems(
+      sub,
+      (color) => this._setWindowColor(metaWindow, color),
+    );
+
+    const resetItem = new PopupMenu.PopupMenuItem("Use app colour");
+    resetItem.connect(
+      "activate",
+      () => this._borderManager.setWindowOverride(metaWindow, null),
+    );
+    sub.addMenuItem(resetItem);
+
+    sub.addMenuItem(new PopupMenu.PopupSeparatorMenuItem("Title bar"));
+
+    const current = this._borderManager.getWindowOverride(metaWindow);
+    const tintItem = new PopupMenu.PopupSwitchMenuItem(
+      "Tint title bar",
+      !!current?.titleTint,
+    );
+    tintItem.connect("toggled", (_item, state) => {
+      const override = this._borderManager.getWindowOverride(metaWindow) || {};
+      this._borderManager.setWindowOverride(metaWindow, {
+        ...override,
+        enabled: true,
+        titleTint: state,
+      });
+    });
+    sub.addMenuItem(tintItem);
+  }
+
+  _addColorItems(targetMenu, onPick) {
+    for (const color of COLORS) {
+      const item = new PopupMenu.PopupMenuItem(color.name);
+      item.insert_child_at_index(createSwatch(color.value), 0);
+      item.connect("activate", () => onPick(color.value));
+      targetMenu.addMenuItem(item);
+    }
+
+    const offItem = new PopupMenu.PopupMenuItem("No border");
+    offItem.connect("activate", () => onPick(null));
+    targetMenu.addMenuItem(offItem);
+  }
+
+  _setWindowColor(metaWindow, color) {
+    const override = color === null
+      ? { enabled: false }
+      : { enabled: true, activeColor: color, inactiveColor: color };
+    this._borderManager.setWindowOverride(metaWindow, override);
+  }
+}


### PR DESCRIPTION
Two additions, in separate commits so you can take either on its own.

**Window picker in prefs.** Setting up an app config meant leaving prefs to run `xprop` for the WM_CLASS. The shell side now lists open windows over D-Bus, and the *Add App Config* row gets a button that fills the key in. GNOME's own `org.gnome.Shell.Introspect` rejects callers outside its allowlist, so prefs can't use it and the extension exposes its own small read-only interface instead.

**Per-window colours.** App-keyed config can't tell two windows of the same app apart, which is exactly when a colour is useful. Right-click a title bar (or Alt+Space) and the menu carries a *Window colour* submenu that colours that one window.

The override lives on the `Meta.Window` and dies with it — window ids aren't stable across sessions, so persisting it would be meaningless. It's merged over the app config and memoised, since configs are compared by reference to decide whether to repaint.

The same submenu can tint the title bar. The title bar itself can't be recoloured — CSD apps paint it in their own process, SSD frames come from mutter's theme — so a translucent wash goes over that strip instead. Its height is measured exactly for server-side decorations via `frame_rect_to_client_rect`; CSD apps fall back to the 46px that GTK's own themes set for `headerbar`, scaled for HiDPI.

One note on the hook: `WindowMenu` is a plain ES class and `WindowMenuManager` builds it from a module-local binding, so patching the export or a `_init` doesn't work — wrapping the manager method is the seam that does.

Tested on GNOME 46 / X11 (Ubuntu 24.04); I haven't been able to try Wayland or 48/49. I couldn't run `make fmt` either, no nix on this machine, so if deno fmt disagrees anywhere just say and I'll push a fixup.
